### PR TITLE
Switch failure mode

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -11,7 +11,7 @@ fail() {
   exit 1
 }
 
-curl_opts=(-fsSL)
+curl_opts=(--fail-with-body -sSL)
 
 if [ -n "${GITHUB_API_TOKEN:-}" ]; then
   curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")


### PR DESCRIPTION
On Fedora 38 `-f` causes complete failure. Whereas `--fail-with-body` succeeds fetching archive