### PR TITLE
Add curl version check

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -11,7 +11,19 @@ fail() {
   exit 1
 }
 
-curl_opts=(--fail-with-body -sSL)
+version_above(){
+  local _ver=${1}
+  local _than_ver=${2}
+  [  "$_than_ver" = $(echo -e "$_ver\n$_than_ver" | sort -V | head -n1) ]
+}
+
+curl_version=$(curl --version | awk 'FNR==1 {print $2}')
+
+if version_above ${curl_version} '7.76.0'; then
+  curl_opts=(--fail-with-body -sSL)
+else
+  curl_opts=(-fsSL)
+fi
 
 if [ -n "${GITHUB_API_TOKEN:-}" ]; then
   curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -11,7 +11,7 @@ fail() {
   exit 1
 }
 
-version_above() {
+version_gte() {
   local _ver=${1}
   local _than_ver=${2}
   [ "$_than_ver" = $(echo -e "$_ver\n$_than_ver" | sort -V | head -n1) ]
@@ -19,7 +19,7 @@ version_above() {
 
 curl_version=$(curl --version | awk 'FNR==1 {print $2}')
 
-if version_above ${curl_version} '7.76.0'; then
+if version_gte ${curl_version} '7.76.0'; then
   curl_opts=(--fail-with-body -sSL)
 else
   curl_opts=(-fsSL)

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -14,7 +14,7 @@ fail() {
 version_above(){
   local _ver=${1}
   local _than_ver=${2}
-  [  "$_than_ver" = $(echo -e "$_ver\n$_than_ver" | sort -V | head -n1) ]
+  [ "$_than_ver" = $(echo -e "$_ver\n$_than_ver" | sort -V | head -n1) ]
 }
 
 curl_version=$(curl --version | awk 'FNR==1 {print $2}')

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -11,7 +11,7 @@ fail() {
   exit 1
 }
 
-version_above(){
+version_above() {
   local _ver=${1}
   local _than_ver=${2}
   [ "$_than_ver" = $(echo -e "$_ver\n$_than_ver" | sort -V | head -n1) ]


### PR DESCRIPTION
turns out earlier `curl` (before `7.76.0`) did not have `--fail-with-body` so I've added a check to compensate for that and restore old behaviour for earlier versions of `curl`